### PR TITLE
Fix nested addons EBM usage

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,10 +55,13 @@ function checkIfEngine(parentPkg) {
 function setPublicAssets(trees, brand, origin, isEngine) {
   debugLog(`[EBM] Funneling ${brand} assets to dist/${isEngine ? origin : 'assets'}`);
 
+  const srcDir = isEngine ? `./node_modules/${origin}/` : './';
+  const destDir = isEngine ? origin : '.';
+
   trees.push(
-    new Funnel('./', {
+    new Funnel(srcDir, {
       srcDir: `brand-assets/${brand}/public`,
-      destDir: isEngine ? origin : '.'
+      destDir
     })
   );
 }

--- a/index.js
+++ b/index.js
@@ -39,31 +39,36 @@ module.exports = {
       trees.push(tree);
     }
 
-    setPublicAssets(trees, DEFAULT_BRAND, pkgName, isEngine);
+    this.setPublicAssets(trees, DEFAULT_BRAND, pkgName, isEngine);
+
     if (targetBrand !== DEFAULT_BRAND) {
-      setPublicAssets(trees, targetBrand, pkgName, isEngine);
+      this.setPublicAssets(trees, targetBrand, pkgName, isEngine);
     }
 
     return mergeTrees(trees, { overwrite: true });
+  },
+
+  setPublicAssets(trees, brand, origin, isEngine) {
+    debugLog(`[EBM] Funneling ${brand} assets to dist/${isEngine ? origin : 'assets'}`);
+
+    if (isEngine) {
+      console.log('<<<', origin, this.parent.pkg.root);
+    }
+
+    const srcDir = isEngine ? this.parent.pkg.root : './';
+    const destDir = isEngine ? origin : '.';
+
+    trees.push(
+      new Funnel(srcDir, {
+        srcDir: `brand-assets/${brand}/public`,
+        destDir
+      })
+    );
   }
 };
 
 function checkIfEngine(parentPkg) {
   return parentPkg.keywords && parentPkg.keywords.includes('ember-engine');
-}
-
-function setPublicAssets(trees, brand, origin, isEngine) {
-  debugLog(`[EBM] Funneling ${brand} assets to dist/${isEngine ? origin : 'assets'}`);
-
-  const srcDir = isEngine ? `./node_modules/${origin}/` : './';
-  const destDir = isEngine ? origin : '.';
-
-  trees.push(
-    new Funnel(srcDir, {
-      srcDir: `brand-assets/${brand}/public`,
-      destDir
-    })
-  );
 }
 
 function colorSchemeStyle(targetBrand, root, type) {

--- a/index.js
+++ b/index.js
@@ -51,10 +51,6 @@ module.exports = {
   setPublicAssets(trees, brand, origin, isEngine) {
     debugLog(`[EBM] Funneling ${brand} assets to dist/${isEngine ? origin : 'assets'}`);
 
-    if (isEngine) {
-      console.log('<<<', origin, this.parent.pkg.root);
-    }
-
     const srcDir = isEngine ? this.parent.pkg.root : './';
     const destDir = isEngine ? origin : '.';
 


### PR DESCRIPTION
### What does this PR do?

Ensure the right root dir is used when dealing w/ nested addons when copying brand assets.

Related to: https://github.com/upfluence/backlog/issues/2685

### What are the observable changes?

<!-- Bug: a given issue trail on sentry should stop happening -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled
