### PR TITLE
Decorator: Required brand, call super before model when brand match requirement

### DIFF
--- a/addon/decorators/required-brand.ts
+++ b/addon/decorators/required-brand.ts
@@ -23,6 +23,8 @@ export function requiredBrand(brand: string, fallbackRoute: string) {
         );
         if ((getOwnConfig() as any).brand !== brand) {
           this.router.transitionTo(fallbackRoute);
+        } else {
+          super.beforeModel()
         }
       }
     }


### PR DESCRIPTION
### What does this PR do?

Currently, the use of required-brand decorator prevent the trigger of beforeModel() in route. The objective is to allow this usage when brand match the requirements.

<!-- A brief description of the context of this pull request and its purpose. -->

Related to: #<!-- enter issue number here -->

### What are the observable changes?

<!-- Bug: a given issue trail on sentry should stop happening -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [ ] Properly labeled
