### PR TITLE
[Required brand] decorators: add missing arguments on beforeModel

### DIFF
--- a/addon/decorators/required-brand.ts
+++ b/addon/decorators/required-brand.ts
@@ -1,6 +1,7 @@
 import { getOwnConfig } from '@embroider/macros';
 import { assert } from '@ember/debug';
 import { inject as service } from '@ember/service';
+import Transition from '@ember/routing/transition';
 
 interface Constructable {
   new (...args: any[]): any;
@@ -12,7 +13,7 @@ export function requiredBrand(brand: string, fallbackRoute: string) {
       // @ts-ignore;
       @service declare router;
 
-      beforeModel() {
+      beforeModel(transition: Transition) {
         assert(
           '[EBM][Decorators][requiredBrand] The @brand parameter of type string is mandatory',
           typeof brand === 'string'
@@ -24,9 +25,9 @@ export function requiredBrand(brand: string, fallbackRoute: string) {
         if ((getOwnConfig() as any).brand !== brand) {
           this.router.transitionTo(fallbackRoute);
         } else {
-          super.beforeModel()
+          super.beforeModel(transition);
         }
       }
-    }
+    };
   };
 }


### PR DESCRIPTION
### What does this PR do?

Related to: #[DRA-5001](https://linear.app/upfluence/issue/DRA-5001/oauth-settings-web-create-the-route-wrapper-shell)

### What are the observable changes?

The goal of the PR is to avoid loosing beforeModel arguments when the `required-brand` decorator is used
<!-- Bug: a given issue trail on sentry should stop happening -->

### Good PR checklist

- [x] Title makes sense
- [x] Is against the correct branch
- [x] Only addresses one issue
- [x] Properly assigned
- [ ] Added/updated tests
- [ ] Added/updated documentation
- [x] Properly labeled
